### PR TITLE
Prettier pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+FILES=$(git diff --cached --name-only --diff-filter=ACMR "*.js" "*.jsx" "*.tsx" "*.ts" | sed 's| |\\ |g')
+[ -z "$FILES" ] && exit 0
+
+# Prettify all selected files
+echo "$FILES" | xargs prettier --write
+
+# Add back the modified/prettified files to staging
+echo "$FILES" | xargs git add
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ In the backend directory, install the dependencies using `yarn` and run using `y
 
 In the frontend directory, install the dependencies using `yarn` and run using `yarn start`. View the page on `http://localhost:3000`.
 
+### Formatting
+
+We use [prettier](https://prettier.io/) to format our code. Install it with
+`yarn global add prettier`. Run `git config --local core.hooksPath .githooks/` to add a pre-commit hook that runs prettier before committing.
+
 ## Deployment
 
 Build the frontend using `yarn build`. The built files will appear in `frontend/build/`.


### PR DESCRIPTION
Adds a `.githooks` folder with a pre-commit hook for running prettier. To enable, run `git config --local core.hooksPath .githooks/`.

Added a note in the readme

@Pingviinituutti 