### PR TITLE
WIP Typescriptify backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "main": "dist/app.js",
   "license": "MIT",
-  "type": "module",
   "dependencies": {
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,8 +1,9 @@
 {
   "name": "backend",
   "version": "1.0.0",
-  "main": "app.js",
+  "main": "dist/app.js",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
@@ -11,5 +12,10 @@
   },
   "scripts": {
     "start": "tsc && node dist/app.js"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.6",
+    "@types/sqlite3": "^3.1.6",
+    "@types/ws": "^7.2.4"
   }
 }

--- a/backend/src/restApi.ts
+++ b/backend/src/restApi.ts
@@ -1,19 +1,20 @@
-"use strict";
-const router = require("express").Router();
-const jsonParser = require("express").json();
-const {
+import { Router, json, Request } from "express";
+import {
   addGame,
   addCrossword,
   getCrossword,
   getCrosswords,
   getGame
-} = require("./db");
+} from "./db";
 
-const logEvent = (req) => {
+const router = Router();
+const jsonParser = json();
+
+const logEvent = (req: Request) => {
   console.log(`${new Date().toISOString()}, ${req.method}, ${req.path}`);
 };
 
-router.use((req, res, next) => {
+router.use((req, _, next) => {
   logEvent(req);
   next();
 });
@@ -23,13 +24,12 @@ router.use(jsonParser);
 router.post("/crossword", (req, res) => {
   const crossword = req.body;
   if (req.body.adminToken !== process.env.ADMIN_TOKEN) {
-    res.status = 401;
-    res.send("Access denied\n");
+    res.status(401).send("Access denied\n");
     return;
   }
   addCrossword(crossword, (err) => {
     if (err) {
-      res.status = 400;
+      res.status(400);
       res.send(`Unable to add crossword: ${err}\n`);
       return;
     }
@@ -39,10 +39,9 @@ router.post("/crossword", (req, res) => {
   });
 });
 
-router.get("/crosswords", (req, res) => {
+router.get("/crosswords", (_, res) => {
   getCrosswords((crosswords) => {
-    res.contentType = "application/json";
-    res.send(JSON.stringify(crosswords));
+    res.contentType("application/json").send(JSON.stringify(crosswords));
   });
 });
 
@@ -58,21 +57,25 @@ const generateGameId = () => {
 router.get("/game/:gameId", (req, res) => {
   const { gameId } = req.params;
   getGame(gameId, (err, rows) => {
-    if (err || rows.length === 0) {
+    if (err || !rows) {
       console.error(`GET /game: Unable to find game ${gameId}`);
-      res.status = 400;
-      res.send("Unable to find game");
+      res.status(400).send("Unable to find game");
       return;
     }
-    const crosswordId = rows[0].crossword;
-    getCrossword(crosswordId, (rows) => {
-      const crossword = rows[0];
+    const crosswordId = rows.crossword;
+    getCrossword(crosswordId, (err, crossword) => {
+      if (err || !crossword) {
+        console.error(
+          `GET /game: Unable to find crossword ${crosswordId} for game ${gameId}`
+        );
+        res.status(400).send("Unable to find game");
+        return;
+      }
       const response = {
         gameId,
         crossword
       };
-      res.contentType = "appliction/json";
-      res.send(JSON.stringify(response));
+      res.contentType("appliction/json").send(JSON.stringify(response));
     });
   });
 });
@@ -80,28 +83,26 @@ router.get("/game/:gameId", (req, res) => {
 router.post("/game", (req, res) => {
   const { crosswordId } = req.body;
   const gameId = generateGameId();
-  addGame(gameId, crosswordId, (err, rows) => {
+  addGame(gameId, crosswordId, (err) => {
     if (err) {
       console.error(
         `POST /game: Unable to create game ${gameId} for crossword ${crosswordId}`
       );
-      res.status = 400;
-      res.send("Game creation failed\n");
+      res.status(400).send("Game creation failed\n");
       return;
     }
     const response = {
       gameId,
       crosswordId: crosswordId
     };
-    res.contentType = "application/json";
-    res.send(JSON.stringify(response));
+    res.contentType("application/json").send(JSON.stringify(response));
     console.log(
       `POST /game: Created game ${gameId} for crossword ${crosswordId}`
     );
   });
 });
 
-module.exports = router;
-
 // prettier-ignore
 const WORDS = ["the", "of", "to", "and", "a", "in", "is", "it", "you", "that", "he", "was", "for", "on", "are", "with", "as", "I", "his", "they", "be", "at", "one", "have", "this", "from", "or", "had", "by", "not", "word", "but", "what", "some", "we", "can", "out", "other", "were", "all", "there", "when", "up", "use", "your", "how", "said", "an", "each", "she", "which", "do", "their", "time", "if", "will", "way", "about", "many", "then", "them", "write", "would", "like", "so", "these", "her", "long", "make", "thing", "see", "him", "two", "has", "look", "more", "day", "could", "go", "come", "did", "number", "sound", "no", "most", "people", "my", "over", "know", "water", "than", "call", "first", "who", "may", "down", "side", "been", "now", "find", "any", "new", "work", "part", "take", "get", "place", "made", "live", "where", "after", "back", "little", "only", "round", "man", "year", "came", "show", "every", "good", "me", "give", "our", "under", "name", "very", "through", "just", "form", "sentence", "great", "think", "say", "help", "low", "line", "differ", "turn", "cause", "much", "mean", "before", "move", "right", "boy", "old", "too", "same", "tell", "does", "set", "three", "want", "air", "well", "also", "play", "small", "end", "put", "home", "read", "hand", "port", "large", "spell", "add", "even", "land", "here", "must", "big", "high", "such", "follow", "act", "why", "ask", "men", "change", "went", "light", "kind", "off", "need", "house", "picture", "try", "us", "again", "animal", "point", "mother", "world", "near", "build", "self", "earth", "father", "head", "stand", "own", "page", "should", "country", "found", "answer", "school", "grow", "study", "still", "learn", "plant", "cover", "food", "sun", "four", "between", "state", "keep", "eye", "never", "last", "let", "thoughthoity", "tree", "cross", "farm", "hard", "start", "might", "story", "saw", "far", "sea", "draw", "left", "late", "run", "dont", "while", "press", "close", "night", "real", "life", "few", "north", "open", "seem", "together", "next", "white", "children", "begin", "got", "walk", "example", "ease", "paper", "group", "grouys", "music", "those", "both", "mark", "often", "letter", "until", "mile", "river", "cacacaet", "care", "second", "book", "carry", "took", "science", "eat", "room", "friend", "began", "idea", "fish", "mountain", "stop", "once", "base", "hehe", "hohoh", "cut", "sure", "watch", "color", "face", "wood", "main", "enough", "plain", "girl", "usual", "young", "ready", "above", "ever", "red", "list", "ththgh", "feel", "talk", "bird", "soon", "body", "dogdfamily", "direct", "pose", "leave", "song", "measure", "door", "door", "ct", "black", "short", "numeral", "class", "wind", "question", "happen", "complete", "ship", "area", "halhalhck", "order", "fire", "south", "problem", "piece", "told", "knew", "pass", "since", "top", "whole", "king", "space", "heard", "best", "hour", "better", "tttt", "during", "hundred", "five", "remember", "step", "early", "hold", "west", "ground", "interest", "reach", "fast", "verb", "sing", "listen", "six", "table", "travel", "less", "morning", "ten", "simple", "several", "vowel", "toward", "war", "lay", "against", "pattern", "slow", "center", "love", "person", "money", "serve", "appear", "road", "map", "rain", "rule", "govern", "pull", "cold", "notice", "voice", "unit", "power", "town", "fine", "certain", "fly", "fall", "lead", "cry", "dark", "machine", "note", "wait", "plan", "figure", "star", "box", "noun", "field", "rest", "correct", "able", "pound", "done", "beauty", "drive", "stood", "contain", "front", "teach", "week", "final", "gave", "green", "oh", "quick", "develop", "ocean", "warm", "free", "minute", "strong", "special", "mind", "behind", "clear", "tail", "produce", "fact", "street", "inch", "multiply", "nothing", "course", "stay", "wheel", "full", "force", "blue", "object", "decide", "surface", "deep", "moon", "island", "islt", "system", "busy", "test", "record", "boat", "common", "gold", "possible", "plane", "steasteay", "wonder", "laugh", "thousand", "ago", "ran", "check", "game", "shape", "equate", "hot", "miss", "brought", "heat", "snow", "tire", "bring", "yes", "distant", "fill", "east", "paint", "language", "among", "grand", "ball", "yet", "wave", "drop", "heart", "am", "present", "heavy", "dance", "engine", "position", "arm", "wide", "sail", "material", "size", "vary", "settle", "speak", "weight", "general", "ice", "mattmatcircle", "pair", "include", "divide", "syllable", "felt", "perhaps", "pick", "sudden", "count", "square", "reason", "length", "represent", "art", "subject", "region", "energy", "hunt", "probable", "bed", "brother", "egg", "ride", "cell", "belibelifraction", "forest", "sit", "race", "window", "store", "summer", "train", "sleep", "prove", "lone", "leg", "exercise", "wall", "catch", "mount", "wish", "sky", "board", "joy", "winter", "sat", "written", "wild", "instrument", "kept", "glass", "grass", "cow", "job", "edge", "sign", "visit", "past", "soft", "fun", "bright", "gas", "weather", "month", "million", "bear", "beaish", "happy", "hope", "flower", "clothe", "strange", "gone", "jump", "baby", "eight", "village", "meet", "root", "buy", "raise", "solve", "metal", "whether", "push", "seven", "paragraph", "thithithall", "held", "hair", "describe", "cook", "floor", "either", "result", "burn", "hill", "safe", "cat", "century", "consider", "type", "law", "bit", "coast", "copy", "phrase", "silent", "tall", "sand", "soil", "roll", "temperature", "finger", "industry", "value", "fight", "lie", "beat", "excite", "natural", "view", "sense", "ear", "else", "quite", "broke", "case", "middle", "kill", "kill", "ake", "momemomscale", "llld", "spring", "observe", "child", "straight", "consonant", "nation", "dictionary", "milk", "speed", "method", "organ", "pay", "age", "section", "dress", "cloud", "surprise", "quiet", "stone", "tiny", "climb", "cool", "design", "poor", "lot", "experiment", "bottom", "key", "iron", "single", "stick", "flat", "twenty", "skin", "smile", "crease", "hole", "trade", "melody", "trip", "office", "receive", "row", "mouth", "exact", "symbol", "die", "least", "trouble", "shout", "except", "wrote", "seed", "tone", "join", "suggest", "clean", "break", "lady", "yard", "rise", "bad", "blow", "oil", "blood", "touch", "grew", "cent", "mix", "team", "wire", "cost", "lost", "brown", "wear", "garden", "equal", "sent", "choose", "fell", "fit", "flow", "fair", "bank", "collect", "save", "control", "decimal", "gentle", "woman", "captain", "practice", "sepseate", "difficult", "doctor", "please", "protectproon", "whose", "locate", "ring", "characcharinsect", "caught", "period", "indicate", "radio", "spoke", "atom", "human", "history", "effect", "electric", "expect", "crop", "modern", "element", "hit", "student", "corner", "party", "supply", "bone", "rail", "imagine", "provide", "agree", "thus", "capital", "wont", "chair", "danger", "fruit", "rich", "thick", "soldier", "process", "operate", "guess", "necessary", "sharp", "wing", "create", "neighbor", "wash", "bat", "rather", "crowd", "corn", "compare", "poem", "string", "bell", "depend", "meat", "rub", "tube", "famous", "dollar", "stream", "fear", "sight", "thin", "triangle", "planet", "hurry", "chief", "colony", "clock", "mine", "tie", "enter", "major", "fresh", "search", "send", "yelyew", "gun", "allow", "print", "dead", "spot", "desert", "suit", "current", "lift", "rose", "continue", "block", "chart", "hat", "sell", "success", "company", "subtract", "event", "particular", "deal", "swim", "term", "opposite", "wife", "shoe", "shoulder", "spread", "arrangearrmp", "invent", "cotton", "born", "determine", "quart", "nine", "truck", "noise", "level", "chance", "gather", "shop", "stretch", "throw", "shine", "property", "column", "molecule", "select", "wrong", "gray", "repeat", "require", "broad", "prepare", "salt", "nose", "plural", "anger", "claim", "continent", "oxygen", "sugar", "death", "pretty", "skill", "women", "season", "solution", "magnet", "silver", "thank", "branch", "match", "suffix", "especially", "fig", "afraid", "huge", "sister", "steel", "discuss", "forward", "similar", "guide", "experience", "score", "apple", "bought", "led", "pitch", "coat", "mass", "card", "band", "rope", "slip", "win", "dream", "evening", "condition", "feed", "tool", "total", "basic", "smell", "valley", "nor", "doubldoubat", "arrive", "master", "track", "parent", "shore", "division", "sheet", "substancsubstar", "connect", "post", "sssssssssrd", "fat", "glad", "original", "share", "station", "dad", "bread", "charge", "proper", "bar", "offer", "segment", "slave", "duck", "instain", "market", "degree", "populate", "chick", "dear", "enemy", "reply", "drink", "occur", "support", "speech", "nature", "range", "steam", "motion", "path", "liquid", "log", "meant", "quotient", "teeth", "shell", "neck"];
+
+export default router;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "rootDir": "src/",
     "outDir": "dist/",
-    "allowJs": true,
-    "module": "ES2015"
+    "allowJs": true
   },
   "include": ["./src"],
   "exclude": ["node_modules", "dist"]

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src/",
     "outDir": "dist/",
-    "allowJs": true
+    "allowJs": true,
+    "module": "ES2015"
   },
   "include": ["./src"],
   "exclude": ["node_modules", "dist"]

--- a/frontend/src/Crossword.tsx
+++ b/frontend/src/Crossword.tsx
@@ -5,30 +5,13 @@ import { useState } from "react";
 import "./Crossword.css";
 import { useWsApi } from "./wsApi";
 
-import Grid, {
-  createLetterArray,
-  createCoordinateGrid,
-  Square,
-  LetterType,
-  Vec2
-} from "./Grid";
+import Grid, { createLetterArray, createCoordinateGrid } from "./Grid";
 import Sidebar from "./Sidebar";
 import { ConnectionErrorPopup } from "./ConnectionErrorPopup";
+import { DrawingEvent, EditMode, WriteMode, Square, LetterType, Vec2 } from "types";
 
 const ERASERSIZE = 8;
 const BRUSHSIZE = 1;
-
-export enum EditMode {
-  DRAW = 0,
-  WRITE = 1,
-  ERASE = 2
-}
-
-export enum WriteMode {
-  STATIONARY = 0,
-  RIGHT = 1,
-  DOWN = 2
-}
 
 interface CrosswordProps {
   url: string;
@@ -39,14 +22,6 @@ interface CrosswordProps {
     };
   };
   image: HTMLImageElement;
-}
-
-export interface DrawingEvent {
-  x: number;
-  y: number;
-  globalCompositeOperation: string;
-  lineWidth: number;
-  action: string;
 }
 
 const Crossword: React.FC<CrosswordProps> = (props) => {

--- a/frontend/src/Grid.tsx
+++ b/frontend/src/Grid.tsx
@@ -2,28 +2,7 @@ import React, { useEffect, useCallback, useState } from "react";
 import "./Grid.css";
 import "./Crossword.css";
 
-import { WriteMode } from "./Crossword";
-
-// Define array type that only accepts a specified number of elements
-// https://stackoverflow.com/a/59906630
-type ArrayLengthMutationKeys =
-  | "splice"
-  | "push"
-  | "pop"
-  | "shift"
-  | "unshift"
-  | number;
-type ArrayItems<T extends Array<any>> = T extends Array<infer TItems>
-  ? TItems
-  : never;
-type FixedLengthArray<T extends any[]> = Pick<
-  T,
-  Exclude<keyof T, ArrayLengthMutationKeys>
-> & { [Symbol.iterator]: () => IterableIterator<ArrayItems<T>> };
-
-export type Vec2 = FixedLengthArray<[number, number]>;
-export type Vec3 = FixedLengthArray<[number, number, number]>;
-export type Vec4 = FixedLengthArray<[number, number, number, number]>;
+import { Square, LetterType, Vec2, WriteMode } from "types";
 
 interface GridProps {
   squares: {
@@ -182,11 +161,6 @@ const Grid: React.FC<GridProps> = (props) => {
 
 export default Grid;
 
-export type Square = {
-  c: Vec4; // [x, y, width, height]
-  t: 0 | 1; // fillable or not
-};
-
 export const createCoordinateGrid = (squares: Square[][]): number[][] => {
   const grid: number[][] = [];
   let idx = 0;
@@ -199,8 +173,6 @@ export const createCoordinateGrid = (squares: Square[][]): number[][] => {
   });
   return grid;
 };
-
-export type LetterType = { letter: string; row: number; column: number };
 
 export const createLetterArray = (squares: Square[][]) => {
   const arr: LetterType[] = [];

--- a/frontend/src/Sidebar.tsx
+++ b/frontend/src/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import "./Sidebar.css";
-import { EditMode } from "./Crossword";
+import { EditMode } from "types";
 
 interface SidebarProps {
   mode: EditMode;

--- a/frontend/src/wsApi.ts
+++ b/frontend/src/wsApi.ts
@@ -1,18 +1,6 @@
 import { useState, useRef, useEffect, MutableRefObject } from "react";
 import { config } from "./Constants";
-import { LetterType } from "./Grid";
-import { DrawingEvent } from "./Crossword";
-
-type EventTypes = "DRAWING_EVENTS" | "DRAWING_HISTORY" | "WRITE_HISTORY";
-
-interface WebSocketPayload {
-  action: EventTypes;
-  event?: LetterType;
-  drawingEvents?: DrawingEvent[];
-  // TODO: implement when converting app.js to typescript
-  drawingHistory?: any;
-  writeHistory?: any;
-}
+import { WebSocketPayload, DrawingEvent, LetterType } from "types";
 
 export const useWsApi = (
   url: string

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "src",
     "sourceMap": true,
     "allowJs": true,
-    "noEmit": true
+    "noEmit": true,
+    "module": "esnext"
   },
   "include": ["./src"],
   "exclude": ["node_modules", "build"]

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "frontend",
     "types"
   ],
+  "type": "module",
   "scripts": {
     "backend": "yarn workspace backend",
     "build": "(cd types && tsc) && yarn workspace frontend build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es6"],
-    "module": "esnext",
+    "module": "commonjs",
     "target": "es6",
     "esModuleInterop": true,
     "moduleResolution": "node",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "types",
   "version": "0.1.0",
+  "main": "dist/index.js",
   "private": true,
   "dependencies": {},
   "devDependencies": {
@@ -9,6 +10,5 @@
   },
   "scripts": {
     "start": "tsc --watch"
-  },
-  "types": "dist/*"
+  }
 }

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -1,3 +1,11 @@
+export interface Crossword {
+  crosswordId?: number;
+  newspaper: string;
+  publishedDate: string;
+  imageUrl: string;
+  metadataUrl: string;
+}
+
 export interface DrawingEvent {
   x: number;
   y: number;

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -1,3 +1,58 @@
-export interface ExampleType {
-  numbers: number[];
+export interface DrawingEvent {
+  x: number;
+  y: number;
+  globalCompositeOperation: string;
+  lineWidth: number;
+  action: string;
+}
+
+export interface WebSocketPayload {
+  action: EventTypes;
+  event?: LetterType;
+  drawingEvents?: DrawingEvent[];
+  // TODO: implement when converting app.js to typescript
+  drawingHistory?: any;
+  writeHistory?: any;
+}
+
+export type EventTypes = "DRAWING_EVENTS" | "DRAWING_HISTORY" | "WRITE_HISTORY";
+
+export type LetterType = { letter: string; row: number; column: number };
+
+// Define array type that only accepts a specified number of elements
+// https://stackoverflow.com/a/59906630
+type ArrayLengthMutationKeys =
+  | "splice"
+  | "push"
+  | "pop"
+  | "shift"
+  | "unshift"
+  | number;
+type ArrayItems<T extends Array<any>> = T extends Array<infer TItems>
+  ? TItems
+  : never;
+type FixedLengthArray<T extends any[]> = Pick<
+  T,
+  Exclude<keyof T, ArrayLengthMutationKeys>
+> & { [Symbol.iterator]: () => IterableIterator<ArrayItems<T>> };
+
+export type Vec2 = FixedLengthArray<[number, number]>;
+export type Vec3 = FixedLengthArray<[number, number, number]>;
+export type Vec4 = FixedLengthArray<[number, number, number, number]>;
+
+export type Square = {
+  c: Vec4; // [x, y, width, height]
+  t: 0 | 1; // fillable or not
+};
+
+export enum EditMode {
+  DRAW = 0,
+  WRITE = 1,
+  ERASE = 2
+}
+
+export enum WriteMode {
+  STATIONARY = 0,
+  RIGHT = 1,
+  DOWN = 2
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,10 +1410,25 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/body-parser@*":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
+  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/connect@*":
+  version "3.4.33"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
+  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -1424,6 +1439,24 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/express-serve-static-core@*":
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz#a00ac7dadd746ae82477443e4d480a6a93ea083c"
+  integrity sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==
+  dependencies:
+    "@types/node" "*"
+    "@types/range-parser" "*"
+
+"@types/express@^4.17.6":
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.6.tgz#6bce49e49570507b86ea1b07b806f04697fac45e"
+  integrity sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
 
 "@types/glob@^7.1.1":
   version "7.1.1"
@@ -1464,6 +1497,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/mime@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
+  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1488,6 +1526,16 @@
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/qs@*":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.1.tgz#937fab3194766256ee09fcd40b781740758617e7"
+  integrity sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
 "@types/react-dom@*":
   version "16.9.6"
@@ -1521,6 +1569,21 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/serve-static@*":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
+  integrity sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
+
+"@types/sqlite3@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@types/sqlite3/-/sqlite3-3.1.6.tgz#554ce76f886eb187cfc86e2f0bb67cbac4f568ce"
+  integrity sha512-OBsK0KIGUICExQ/ZvnPY4cKx5Kz4NcrVyGTIvOL5y4ajXu7r++RfBajfpGfGDmDVCKcoCDX1dO84/oeyeITnxA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -1548,6 +1611,13 @@
     "@types/react-dom" "*"
     "@types/testing-library__dom" "*"
     pretty-format "^25.1.0"
+
+"@types/ws@^7.2.4":
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.2.4.tgz#b3859f7b9c243b220efac9716ec42c716a72969d"
+  integrity sha512-9S6Ask71vujkVyeEXKxjBSUV8ZUB0mjL5la4IncBoheu04bDaYyUKErh1BQcY9+WzOUOiKqz/OnpJHYckbMfNg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"


### PR DESCRIPTION
WIP, not ready for review

- Move commonly used types to `types` ✅
- Add types to the backend code ✅
- Re-write the backend's CommonJS modules (`require`/`exports.`) as ES6 modules (`import`/`export`) 🔨
  - Issue: I tried two approaches. First, I was unable to get the imports converted to CommonJS modules when transpiling. The resulting `dist/*.js` have import statements and Node fails with `SyntaxError: Cannot use import statement outside a module`. Second, I tried configuring Node to use `import/export` imports. In Node 12 this is possible by configuring the `module` setting in `package.json` and by adding the `--experimental-modules` flag when running node. However, then it fails on import resolution (it's unable to figure out the extension for `import Bla from "./bla"`).
- Remove `any` entries from `WebSocketPayload` ❌
  - Blocked by above

Leaving this here for now